### PR TITLE
(refactor) enhance chaostoolkit experiment to lend itself to orchestration by  chaos operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - stage: build docker images
       name: build docker image chaostoolkit
       script:
-      - make chaostoolkit-aws
+      - make chaostoolkit
 #    - stage: build docker images
 #      name: build docker image mysql-client
 #      script:

--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,6 @@ _push_tests_fio_image:
 
 fio: deps _build_tests_fio_image _push_tests_fio_image
 
-
-_build_tests_chaostoolkit_image:
-	@echo "INFO: Building container image for performing chaostoolkit"
-	cd chaostoolkit-aws && docker build -t openebs/tests-chaostoolkit .
-
-_push_tests_chaostoolkit_image:
-	@echo "INFO: Publish container (openebs/tests-chaostoolkit)"
-	cd chaostoolkit-aws/buildscripts && ./push
-
-chaostoolkit: deps _build_tests_chaostoolkit_image _push_tests_chaostoolkit_image
-
 _build_tests_dd_client:
 	@echo "INFO: Building container image for performing dd client"
 	cd dd-client && docker build -t openebs/tests-dd-client .
@@ -299,6 +288,16 @@ _push_tests_app_cpu_stress_image:
 	cd app-cpu-stress/buildscripts && ./push
 
 app-cpu-stress: deps _build_tests_app_cpu_stress_image _push_tests_app_cpu_stress_image 
+
+_build_tests_chaostoolkit_image:
+	@echo "INFO: Building container image for performing chaostoolkit tests"
+	cd chaostoolkit && docker build -t litmuschaos/chaostoolkit .
+
+_push_tests_chaostoolkit_image:
+	@echo "INFO: Publish container (litmuschaos/chaostoolkit)"
+	cd chaostoolkit/buildscripts && ./push
+
+chaostoolkit: deps _build_tests_chaostoolkit_image _push_tests_chaostoolkit_image 
 
 # busybox: deps _build_tests_busybox_client_image _push_tests_busybox_client_image
 

--- a/chaostoolkit/Dockerfile
+++ b/chaostoolkit/Dockerfile
@@ -5,11 +5,10 @@ LABEL name=chaostoolkit
 
 
 ### upgrade and setup python
-RUN apt-get update && \
-    apt-get -y install gcc python3-pip python-dev && \
-    curl \
-    pip3 install --upgrade pip
-### upgrade and setup python
+RUN apt-get update \
+    && apt-get -y install gcc python-pip python3-pip python-dev curl \
+    && pip3 install --upgrade pip \
+    && pip2 install jinja2 pyYaml
 
 ### Setup kops
 WORKDIR /app
@@ -28,25 +27,22 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 ### Setup kubectl
 
 ### Other Packages 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get install -y texlive-latex-base \
-      texlive-fonts-recommended \
-      texlive-latex-extra \
-      vim \
-      net-tools && \
-    curl -Lvf -o pandoc.deb https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb && \
-    dpkg -i pandoc.deb && \
-    apt-get remove -y curl \
-      texlive-latex-extra-doc \
-      texlive-latex-recommended-doc \
-      texlive-latex-base-doc \
-      texlive-fonts-recommended-doc \
-      texlive-pstricks-doc \
-      texlive-pictures-doc && \
-    apt-get autoremove && \
-    apt-get autoclean
-### Other Packages
-
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y texlive-latex-base texlive-fonts-recommended texlive-latex-extra \
+    vim \
+    net-tools \
+    libcairo2-dev \ 
+    && curl -Lvf -o pandoc.deb https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb \
+    && dpkg -i pandoc.deb \
+    && apt-get remove -y curl \
+    texlive-latex-extra-doc \
+    texlive-latex-recommended-doc \
+    texlive-latex-base-doc \
+    texlive-fonts-recommended-doc \
+    texlive-pstricks-doc \
+    texlive-pictures-doc \
+    && apt-get autoremove || true \
+    && apt-get autoclean || true
 
 ### Copy Data 
 WORKDIR /app/data

--- a/chaostoolkit/buildscripts/push
+++ b/chaostoolkit/buildscripts/push
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( docker images -q openebs/chaostoolkit )
+IMAGEID=$( docker images -q litmuschaos/chaostoolkit )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   docker login -u "${DNAME}" -p "${DPASS}"; 
   #Push to docker hub repository with latest tag
-  docker tag ${IMAGEID} openebs/chaostoolkit:latest
-  docker push openebs/chaostoolkit:latest;
+  docker tag ${IMAGEID} litmuschaos/chaostoolkit:latest
+  docker push litmuschaos/chaostoolkit:latest;
 else
   echo "No docker credentials provided. Skip uploading openebs/tests-chaostoolkit:latest to docker hub"; 
 fi;

--- a/chaostoolkit/data/chaos-result.j2
+++ b/chaostoolkit/data/chaos-result.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosResult
+metadata:
+  {% if instance_id is defined %}
+  name: {{ c_experiment }}-{{ instance_id }}
+  {% else %}
+  name: {{ c_experiment }}
+  {% endif %} 
+spec:
+  # holds the state of testcase,  manually updated by json merge patch
+  # verdict is the useful value today, but anticipate phase use in future 
+  experimentstatus: 
+    phase: {{ phase }}  
+    verdict: {{ verdict }} 
+

--- a/chaostoolkit/data/journal.json
+++ b/chaostoolkit/data/journal.json
@@ -1,0 +1,159 @@
+{
+  "chaoslib-version": "1.8.1",
+  "run": [
+    {
+      "start": "2020-02-27T18:31:46.266408",
+      "status": "succeeded",
+      "duration": 0.030253,
+      "output": null,
+      "activity": {
+        "type": "action",
+        "name": "Terminate_pod",
+        "pauses": {
+          "after": 20
+        },
+        "provider": {
+          "type": "python",
+          "arguments": {
+            "name_pattern": "${app_name}",
+            "qty": 1,
+            "rand": true,
+            "ns": "${name_space}",
+            "label_selector": "app=${app_name}",
+            "mode": "fixed"
+          },
+          "func": "terminate_pods",
+          "module": "chaosk8s.pod.actions"
+        }
+      },
+      "end": "2020-02-27T18:31:46.296661"
+    }
+  ],
+  "platform": "Linux-4.15.0-1044-gke-x86_64-with-Ubuntu-16.04-xenial",
+  "steady_states": {
+    "after": {
+      "probes": [
+        {
+          "start": "2020-02-27T18:32:06.318533",
+          "tolerance_met": true,
+          "status": "succeeded",
+          "duration": 0.022319,
+          "output": 2,
+          "activity": {
+            "type": "probe",
+            "name": "there-should-be-at-least-2-running-app-replicas",
+            "tolerance": 2,
+            "provider": {
+              "type": "python",
+              "arguments": {
+                "ns": "${name_space}",
+                "label_selector": "app=${app_name}"
+              },
+              "func": "count_pods",
+              "module": "chaosk8s.pod.probes"
+            }
+          },
+          "end": "2020-02-27T18:32:06.340852"
+        }
+      ],
+      "steady_state_met": true
+    },
+    "before": {
+      "probes": [
+        {
+          "start": "2020-02-27T18:31:46.246647",
+          "tolerance_met": true,
+          "status": "succeeded",
+          "duration": 0.018435,
+          "output": 2,
+          "activity": {
+            "type": "probe",
+            "name": "there-should-be-at-least-2-running-app-replicas",
+            "tolerance": 2,
+            "provider": {
+              "type": "python",
+              "arguments": {
+                "ns": "${name_space}",
+                "label_selector": "app=${app_name}"
+              },
+              "func": "count_pods",
+              "module": "chaosk8s.pod.probes"
+            }
+          },
+          "end": "2020-02-27T18:31:46.265082"
+        }
+      ],
+      "steady_state_met": true
+    }
+  },
+  "end": "2020-02-27T18:32:06.342829",
+  "node": "k8-pod-delete-v95zf-rsbvj",
+  "rollbacks": [],
+  "start": "2020-02-27T18:31:46.245706",
+  "deviated": false,
+  "status": "completed",
+  "duration": 20.09839367866516,
+  "experiment": {
+    "steady-state-hypothesis": {
+      "probes": [
+        {
+          "type": "probe",
+          "name": "there-should-be-at-least-2-running-app-replicas",
+          "tolerance": 2,
+          "provider": {
+            "type": "python",
+            "arguments": {
+              "ns": "${name_space}",
+              "label_selector": "app=${app_name}"
+            },
+            "func": "count_pods",
+            "module": "chaosk8s.pod.probes"
+          }
+        }
+      ],
+      "title": "Killing the pod where application is running"
+    },
+    "dry": false,
+    "tags": [
+      "service",
+      "kubernetes",
+      "spring"
+    ],
+    "version": "1.0.0",
+    "rollbacks": [],
+    "method": [
+      {
+        "type": "action",
+        "name": "Terminate_pod",
+        "pauses": {
+          "after": 20
+        },
+        "provider": {
+          "type": "python",
+          "arguments": {
+            "name_pattern": "${app_name}",
+            "qty": 1,
+            "rand": true,
+            "ns": "${name_space}",
+            "label_selector": "app=${app_name}",
+            "mode": "fixed"
+          },
+          "func": "terminate_pods",
+          "module": "chaosk8s.pod.actions"
+        }
+      }
+    ],
+    "description": "Can our consumer survive gracefully a provider's failure?",
+    "configuration": {
+      "app_name": {
+        "type": "env",
+        "key": "LABEL_NAME"
+      },
+      "name_space": {
+        "type": "env",
+        "key": "NAME_SPACE"
+      }
+    },
+    "title": "System is resilient to provider's failures"
+  }
+}

--- a/chaostoolkit/data/k8_wrapper.py
+++ b/chaostoolkit/data/k8_wrapper.py
@@ -3,14 +3,46 @@ import sys
 import os
 import argparse
 import logging
+import json
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import yaml
 
 
 __author__ = 'Sumit_Nagal@intuit.com'
 
+####################################
+#      Function definitions        #
+####################################
+
+"""
+run_shell_task() runs a shell command and prints the output as it executes. 
+It takes a list of strings that comprises the command itself, as the sole arg.
+"""
+def run_shell_task(cmd_arg_list):
+    run_cmd = subprocess.Popen(cmd_arg_list, stdout=subprocess.PIPE, env=os.environ.copy())
+    run_cmd.communicate()
+
+"""
+chaos_result_tracker() creates/patches the litmus chaosresult custom resource in the provided namespace.
+Typically invoked before and after chaos, and takes the .spec.phase, .spec.verdict & namespace as as args.
+"""
+def chaos_result_tracker(exp_name, exp_phase, exp_verdict, ns):
+    env_tmpl = Environment(loader = FileSystemLoader('./'), trim_blocks=True, lstrip_blocks=True, autoescape=select_autoescape(['yaml']))
+    template = env_tmpl.get_template('chaos-result.j2')
+    updated_chaosresult_template = template.render(c_experiment=exp_name, phase=exp_phase, verdict=exp_verdict)
+    with open('chaosresult.yaml', "w+") as f:
+        f.write(updated_chaosresult_template)
+    chaosresult_update_cmd_args_list = ['kubectl','apply', '-f', 'chaosresult.yaml', '-n', ns]
+    run_shell_task(chaosresult_update_cmd_args_list)
+
+####################################
+# Start of Python Chaos Experiment #
+####################################
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument("-file", action='store',
-                    default="experiment.json",
+                    default="pod-app-kill-count.json",
                     dest = "file",
                     help="Chaos file to chose for execution"
                     )
@@ -35,6 +67,11 @@ parser.add_argument('-percentage', action='store',
 
 results = parser.parse_args()
 
+# adopt log structure used by the chaostoolkit framework
+logging.basicConfig(
+    format="[%(asctime)s %(levelname)-2s] [%(module)s:%(lineno)s] %(message)s",
+    level=logging.DEBUG,
+    datefmt='%Y-%m-%d %H:%M:%S')
 
 env_params = dict(
         LABEL_NAME=results.label,
@@ -44,20 +81,50 @@ env_params = dict(
         FILE=results.file
     )
 
+# check (&set) env based on input and/or default values
 for key in env_params:
     if key in os.environ.keys():
-        print("Environment exists")
+        logging.debug("Environment exists for key: %s", key)
     else:
         os.environ[key] = env_params[key]
 
 filename = os.environ['FILE']
+namespace = os.environ['NAME_SPACE']
 
-execcommandlist = []
-execcommandlist.append("chaos")
-execcommandlist.append("--verbose")
-execcommandlist.append("run")
-execcommandlist.append(filename)
-runchaoscmd = subprocess.Popen(execcommandlist, stdout=subprocess.PIPE, encoding='utf-8', env=os.environ.copy())
+# if the env CHAOSENGINE is defined, suffix it standard experiment name 
+# to generate the fully-qualified chaos experiment/chaosresult name 
+experiment_name = 'k8-pod-delete'
+if 'CHAOSENGINE' in os.environ.keys():
+    experiment_name = os.environ['CHAOSENGINE'] + '-' + experiment_name 
 
-for line in runchaoscmd.stdout:
-    logging.info(line)
+# create chaosresult custom resource with phase=Running, verdict=Awaited
+chaos_result_tracker(experiment_name, 'Running', 'Awaited', namespace)
+
+# run chaos and store status into journal.json
+chaos_command_list = ['chaos', '--verbose', 'run', '--journal-path', 'journal.json', filename]
+run_shell_task(chaos_command_list)
+
+# extract stage-wise success of experiment from the journal.json
+with open('journal.json') as fp:
+    data = json.load(fp)
+
+pre_chaos_steady_state_check = data['steady_states']['before']['probes'][0]['status']
+logging.info('status of pre-chaos steady_state_check is: %s', pre_chaos_steady_state_check)
+
+run_status = data['run'][0]['status']
+logging.info('status of chaos_injection_action is: %s', run_status)
+
+post_chaos_steady_state_check = data['steady_states']['after']['probes'][0]['status']
+logging.info('status of post-chaos steady_state_check is: %s', post_chaos_steady_state_check)
+
+stage_level_verdicts = [pre_chaos_steady_state_check, run_status, post_chaos_steady_state_check]
+
+# derive chaos experiment verdict as a logical AND of stage-wise results
+if len(set(stage_level_verdicts)) == 1 and 'succeeded' in stage_level_verdicts:
+    # patch chaosresult custom resource with phase=Completed, verdict=Pass
+    chaos_result_tracker(experiment_name, 'Completed', 'Pass', namespace)
+    logging.info('The chaos experiment verdict is: Pass')
+else:
+    # patch chaosresult custom resource with phase=Completed, verdict=Fail
+    chaos_result_tracker(experiment_name, 'Completed', 'Fail', namespace)
+    logging.info('The chaos experiment verdict is: Fail')

--- a/chaostoolkit/data/pod-app-kill-count.json
+++ b/chaostoolkit/data/pod-app-kill-count.json
@@ -14,7 +14,7 @@
     },
     "name_space": {
       "type": "env",
-      "key": "NAMESPACE"
+      "key": "NAME_SPACE"
     }
   },
   "steady-state-hypothesis": {
@@ -22,8 +22,8 @@
     "probes": [
       {
         "type": "probe",
-        "name": "there-should-be-fixed-running-instance-5-node-3-master",
-        "tolerance": 3,
+        "name": "there-should-be-at-least-2-running-app-replicas",
+        "tolerance": 2,
         "provider": {
           "type": "python",
           "module": "chaosk8s.pod.probes",

--- a/chaostoolkit/install.sh
+++ b/chaostoolkit/install.sh
@@ -12,6 +12,6 @@ do
 done
 rm -rf /tmp/* /root/.cache
 
-nohup kubectl proxy --port=8080 &>/dev/null &
-wait
+#nohup kubectl proxy --port=8080 &>/dev/null &
+#wait
 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR consists of changes to the experiment artefacts to ensure it can be run by the chaos-operator. The changes in each component are explained below: 

### Chaostoolkit Dockerfile/Image
- Removes the steps to start kubectl proxy in the install script as it no longer serves as entrypoint. Uses the CHAOSTOOLKIT_IN_POD env as per chaostoolkit documentation. 
- Adds package `libcairo2-dev` to aid generation of chaostoolkit reports
- Ignores errors on `apt autoremove/autoclean` steps to account for broken network connectivity/other failures
- Fixes some typos/syntax issues with package install steps

### Python Script to execute chaostoolkit experiment

- Runs the chaos command with `--journal-path` arg to output a json summary which is used to derive stage-wise success (pre-chaos steady-state check/ chaos-injection / post-chaos s.s check)
- Adds functions to derive and generate/patch a chaosresult resource before and after experiment execution with appropriate verdict. Uses jinja templating & kubectl commands to achieve this. 
- Modularizes the code a bit for reuse & adds additional logs with same structure as the chaostoolkit

### Chaostoolkit chaos manifest (experiment json) 

- Makes minor changes to names/keys and uses minimum toleration to make it more meaningful.

**Special notes for your reviewer**:

-  Also makes changes to the CI scripts to build the chaostoolkit image
- Adds an example/reference json output of the test 
- Log snippets indicating successful run via the chaos-operator are provided here for reference: 

```
Every 1.0s: kubectl get pods                                                                                                      Fri Feb 28 18:57:11 2020
NAME                         READY   STATUS    RESTARTS   AGE
k8-pod-delete-kyvfnr-6h9wp   1/1     Running   0          21s
nginx-65f88748fd-lkwjb       1/1     Running   0          109m
nginx-65f88748fd-q22hp       1/1     Running   0          14s
nginx-chaos-runner           1/1     Running   0          23s
```

```
Status:
  Experiments:
    Last Update Time:  2020-02-28T19:23:42Z
    Name:              k8-pod-delete-omks8z
    Status:            Execution Successful
    Verdict:           Pass
Events:
  Type    Reason               Age   From            Message
  ----    ------               ----  ----            -------
  Normal  Started ChaosEngine  62s   chaos-operator  Creating the experiment resources
```